### PR TITLE
Adding example of multi-classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@
     - `-c` or `--classes` specifies the "List of Classes to Predict". If this is defined, it will replace the `config_file_path` argument. We expect each class to be of the form `-c {CLASS_NAME}`. 
         - Repeat as necessary (e.g. `python scripts/classification_on_collection.py -c dog -c parrot -c cat -c bear`)
 
+### Running Multi-Classification
+- **Quickstart**: From the root directory, execute `python scripts/multi_classify_on_collection.py`.
+- Add image data that you're interested in running multiple parallel classification models on to the `data` folder. 
+- You can specify multiple classifiers of interest with several filepaths that point to a json (e.g. `configs/classifier.json` & `configs/alt_classifier.json`). 
+- Arguments:
+    - `-d` or `--data_dir` specifies the "Directory for Input Data". It defaults to "data". We accept `.png` and `.jpg` image formats. We've added a few samples from [this dataset](https://universe.roboflow.com/roboflow-100/furniture-ngpea) to the folder already! 
+    - `-r` or `--results_dir` specifies the "Directory for Results". It defaults to "results". We write `classification_results.json` to this directory. It specifies classification scores and ultimate class prediction for each input image.
+    - `-f` or `--config_file_paths` specifies the "File Path(s) for Classifier Configuration". It defaults to [`configs/classifier.json`, `configs/alt_classifier.json`].
+        - Repeat as necessary (e.g. `python scripts/classification_on_collection.py -f configs/classifier.json -f configs/alt_classifier.json -f configs/my_third_classifier.json`)
+
 ### Running Detection
 - **Quickstart**: From the root directory, execute `python scripts/detection_on_collection.py -b`.
 - Add image data that you're interested in running a detection model on to the `data` folder. 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 - Add image data that you're interested in running a classification model on to the `data` folder. 
 - You can specify classes of interest via the command line (e.g. `-c dog -c cat`) or with a filepath that points to a json (e.g. `configs/classifier.json`). 
 - Arguments:
-    - `-d` or `--data_dir` specifies the "Directory for Input Data". It defaults to "data". We accept `.png` and `.jpg` image formats. We've added a few samples from [this dataset](https://universe.roboflow.com/roboflow-100/furniture-ngpea) to the folder already! 
+    - `-d` or `--data_dir` specifies the "Directory for Input Data". It defaults to "data". We accept `.png` and `.jpg` image formats. We've added a few samples from [Pexels](https://www.pexels.com/) to the folder already! 
     - `-r` or `--results_dir` specifies the "Directory for Results". It defaults to "results". We write `classification_results.json` to this directory. It specifies classification scores and ultimate class prediction for each input image.
     - `-f` or `--config_file_path` specifies the "File Path for Classifier Configuration". It defaults to "configs/classifier.json".
     - `-c` or `--classes` specifies the "List of Classes to Predict". If this is defined, it will replace the `config_file_path` argument. We expect each class to be of the form `-c {CLASS_NAME}`. 
@@ -22,7 +22,7 @@
 - Add image data that you're interested in running multiple parallel classification models on to the `data` folder. 
 - You can specify multiple classifiers of interest with several filepaths that point to a json (e.g. `configs/classifier.json` & `configs/alt_classifier.json`). 
 - Arguments:
-    - `-d` or `--data_dir` specifies the "Directory for Input Data". It defaults to "data". We accept `.png` and `.jpg` image formats. We've added a few samples from [this dataset](https://universe.roboflow.com/roboflow-100/furniture-ngpea) to the folder already! 
+    - `-d` or `--data_dir` specifies the "Directory for Input Data". It defaults to "data". We accept `.png` and `.jpg` image formats. We've added a few samples from [Pexels](https://www.pexels.com/) to the folder already! 
     - `-r` or `--results_dir` specifies the "Directory for Results". It defaults to "results". We write `multi_classification_results.json` to this directory. It specifies classification scores and ultimate class prediction for each input image.
     - `-f` or `--config_file_paths` specifies the "File Path(s) for Classifier Configuration". It defaults to [`configs/classifier.json`, `configs/alt_classifier.json`].
         - Repeat as necessary (e.g. `python scripts/multi_classify_on_collection.py -f configs/classifier.json -f configs/alt_classifier.json -f configs/my_third_classifier.json`)
@@ -32,7 +32,7 @@
 - Add image data that you're interested in running a detection model on to the `data` folder. 
 - You can specify objects of interest via the command line (e.g. `-c dog -c cat`) or with a filepath that points to a json (e.g. `configs/detector.json`). 
 - Arguments:
-    - `-d` or `--data_dir` specifies the "Directory for Input Data". It defaults to "data". We accept `.png` and `.jpg` image formats. We've added a few samples from [this dataset](https://universe.roboflow.com/roboflow-100/furniture-ngpea) to the folder already! 
+    - `-d` or `--data_dir` specifies the "Directory for Input Data". It defaults to "data". We accept `.png` and `.jpg` image formats. We've added a few samples from [Pexels](https://www.pexels.com/) to the folder already! 
     - `-r` or `--results_dir` specifies the "Directory for Results". It defaults to "results". We write `detection_results.json` to this directory. It specifies classification scores and ultimate class prediction for each input image.
     - `-f` or `--config_file_path` specifies the "File Path for Classifier Configuration". It defaults to "configs/classifier.json".
     - `-c` or `--classes` specifies the "List of Classes to Predict". If this is defined, it will replace the `config_file_path` argument. We expect each class to be of the form `-c {CLASS_NAME}`. 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@
 - You can specify multiple classifiers of interest with several filepaths that point to a json (e.g. `configs/classifier.json` & `configs/alt_classifier.json`). 
 - Arguments:
     - `-d` or `--data_dir` specifies the "Directory for Input Data". It defaults to "data". We accept `.png` and `.jpg` image formats. We've added a few samples from [this dataset](https://universe.roboflow.com/roboflow-100/furniture-ngpea) to the folder already! 
-    - `-r` or `--results_dir` specifies the "Directory for Results". It defaults to "results". We write `classification_results.json` to this directory. It specifies classification scores and ultimate class prediction for each input image.
+    - `-r` or `--results_dir` specifies the "Directory for Results". It defaults to "results". We write `multi_classification_results.json` to this directory. It specifies classification scores and ultimate class prediction for each input image.
     - `-f` or `--config_file_paths` specifies the "File Path(s) for Classifier Configuration". It defaults to [`configs/classifier.json`, `configs/alt_classifier.json`].
-        - Repeat as necessary (e.g. `python scripts/classification_on_collection.py -f configs/classifier.json -f configs/alt_classifier.json -f configs/my_third_classifier.json`)
+        - Repeat as necessary (e.g. `python scripts/multi_classify_on_collection.py -f configs/classifier.json -f configs/alt_classifier.json -f configs/my_third_classifier.json`)
 
 ### Running Detection
 - **Quickstart**: From the root directory, execute `python scripts/detection_on_collection.py -b`.

--- a/configs/alt_classifier.json
+++ b/configs/alt_classifier.json
@@ -1,0 +1,14 @@
+{
+    "classifier_configs": [
+        {
+            "name": "dog",
+            "examples_to_include": ["dog"],
+            "examples_to_exclude": []
+        },
+        {
+            "name": "cat",
+            "examples_to_include": ["cat"],
+            "examples_to_exclude": []
+        }
+    ]
+}

--- a/scripts/classification_on_collection.py
+++ b/scripts/classification_on_collection.py
@@ -18,7 +18,7 @@ DIRECTAI_CLIENT_ID = os.getenv("DIRECTAI_CLIENT_ID")
 DIRECTAI_CLIENT_SECRET = os.getenv("DIRECTAI_CLIENT_SECRET")
 DIRECTAI_BASE_URL = "https://api.alpha.directai.io"
 
-def deploy_classifier(config_file_path, access_token, results_dir, class_name=None):
+def get_classifier_body(config_file_path, class_name=None):
     if (class_name is not None) and len(class_name) > 0:
         classifier_configs = []
         for single_class in class_name:
@@ -31,7 +31,10 @@ def deploy_classifier(config_file_path, access_token, results_dir, class_name=No
     else:
         with open(config_file_path) as f:
             body = json.loads(f.read())
+    
+    return body
 
+def deploy_classifier(body, access_token):
     headers = {
         'Authorization': f"Bearer {access_token}"
     }
@@ -46,11 +49,9 @@ def deploy_classifier(config_file_path, access_token, results_dir, class_name=No
         raise ValueError(deploy_response.json()['message'])
     deployed_classifier_id = deploy_response.json()['deployed_id']
     
-    prep_classification_results_dir(results_dir, body)
-    
     return deployed_classifier_id
 
-def prep_classification_results_dir(results_dir, body):
+def prep_classification_results_dir(body, results_dir):
     # Prepares Results Directory
     if not os.path.exists(results_dir):
         os.makedirs(results_dir)
@@ -74,7 +75,9 @@ def main(data_dir, results_dir, config_file_path, class_name):
         auth_endpoint=DIRECTAI_BASE_URL+"/token"
     )
     
-    deployed_classifier_id = deploy_classifier(config_file_path, access_token, results_dir, class_name)
+    classifier_body = get_classifier_body(config_file_path, class_name)
+    deployed_classifier_id = deploy_classifier(classifier_body, access_token)
+    prep_classification_results_dir(classifier_body, results_dir)
     # Compiled Results
     results = {}
     

--- a/scripts/multi_classify_on_collection.py
+++ b/scripts/multi_classify_on_collection.py
@@ -74,7 +74,7 @@ def main(data_dir, results_dir, config_file_paths):
             )
     
     # Save Inference Results
-    with open(f"{results_dir}/classification_results.json", 'w') as f:
+    with open(f"{results_dir}/multi_classification_results.json", 'w') as f:
         json.dump(results, f)
     
 if __name__ == '__main__':

--- a/scripts/multi_classify_on_collection.py
+++ b/scripts/multi_classify_on_collection.py
@@ -42,6 +42,7 @@ def main(data_dir, results_dir, config_file_paths):
             deployed_classifier_ids.append(deployed_classifier_id)
     else:
         print("Please provide config file paths. Exiting.")
+        return
     
     headers = {
         'Authorization': f"Bearer {access_token}"
@@ -67,11 +68,12 @@ def main(data_dir, results_dir, config_file_paths):
         if classify_response.status_code != 200:
             raise ValueError(classify_response.json())
         results[filename] = classify_response.json()
-        for deployed_classifier_id in results[filename]:
+        for config_file_path, deployed_classifier_id in zip(config_file_paths, deployed_classifier_ids):
             prediction = results[filename][deployed_classifier_id]['pred']
+            stripped_config_name = config_file_path.split("/")[-1].split(".")[0]
             shutil.copy(
                 f"{data_dir}/{filename}",
-                f"{results_dir}/{prediction}/{filename}"
+                f"{results_dir}/{stripped_config_name}/{prediction}/{filename}"
             )
     
     # Save Inference Results

--- a/scripts/multi_classify_on_collection.py
+++ b/scripts/multi_classify_on_collection.py
@@ -1,0 +1,83 @@
+import os
+import sys
+import json
+import requests
+import shutil
+import click
+
+from dotenv import load_dotenv
+from tqdm import tqdm
+
+parent_directory = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(parent_directory)
+from utils import get_directai_access_token, get_file_data
+from classification_on_collection import deploy_classifier
+
+
+load_dotenv()
+DIRECTAI_CLIENT_ID = os.getenv("DIRECTAI_CLIENT_ID")
+DIRECTAI_CLIENT_SECRET = os.getenv("DIRECTAI_CLIENT_SECRET")
+DIRECTAI_BASE_URL = "https://api.alpha.directai.io"
+
+
+@click.command()
+@click.option('-d', '--data-dir', default='data', help='Directory for Input Data')
+@click.option('-r', '--results-dir', default='results', help='Directory for Results')
+@click.option('-f', '--config-file-paths', default=['configs/classifier.json', 'configs/alt_classifier.json'], help='File Path(s) for Classifier Configuration', multiple=True)
+def main(data_dir, results_dir, config_file_paths):
+    # Get Access Token
+    access_token = get_directai_access_token(
+        client_id=DIRECTAI_CLIENT_ID,
+        client_secret=DIRECTAI_CLIENT_SECRET,
+        auth_endpoint=DIRECTAI_BASE_URL+"/token"
+    )
+    
+    deployed_classifier_ids = []
+    if len(config_file_paths) > 0:
+        for config_file_path in config_file_paths:
+            deployed_classifier_id = deploy_classifier(config_file_path, access_token, results_dir)
+            deployed_classifier_ids.append(deployed_classifier_id)
+    else:
+        print("Please provide config file paths. Exiting.")
+    
+    
+    
+    headers = {
+        'Authorization': f"Bearer {access_token}"
+    }
+    
+    # Compiled Results
+    results = {}
+    
+    # Run Classification on Data Collection
+    for filename in tqdm(os.listdir(data_dir)):
+        if filename == '.DS_Store':
+            continue
+        params = {
+            'deployed_ids': deployed_classifier_ids
+        }
+        file_data = get_file_data(f"{data_dir}/{filename}")
+        classify_response = requests.post(
+            f"{DIRECTAI_BASE_URL}/multi_classify",
+            headers=headers, 
+            params=params,
+            files=file_data
+        )
+        if classify_response.status_code != 200:
+            raise ValueError(classify_response.json())
+        results[filename] = classify_response.json()
+        for deployed_classifier_id in results[filename]:
+            prediction = results[filename][deployed_classifier_id]['pred']
+            shutil.copy(
+                f"{data_dir}/{filename}",
+                f"{results_dir}/{prediction}/{filename}"
+            )
+    
+    # Save Inference Results
+    with open(f"{results_dir}/classification_results.json", 'w') as f:
+        json.dump(results, f)
+    
+if __name__ == '__main__':
+    main()
+    
+    

--- a/scripts/multi_classify_on_collection.py
+++ b/scripts/multi_classify_on_collection.py
@@ -34,13 +34,14 @@ def main(data_dir, results_dir, config_file_paths):
     
     deployed_classifier_ids = []
     if len(config_file_paths) > 0:
+        if not os.path.exists(results_dir):
+            os.makedirs(results_dir)
         for config_file_path in config_file_paths:
-            deployed_classifier_id = deploy_classifier(config_file_path, access_token, results_dir)
+            stripped_config_name = config_file_path.split("/")[-1].split(".")[0]
+            deployed_classifier_id = deploy_classifier(config_file_path, access_token, f"{results_dir}/{stripped_config_name}")
             deployed_classifier_ids.append(deployed_classifier_id)
     else:
         print("Please provide config file paths. Exiting.")
-    
-    
     
     headers = {
         'Authorization': f"Bearer {access_token}"


### PR DESCRIPTION
Summary:
Example of multi-classification in action. Open to feedback on the new config as well as the way we're saving results in the `results_dir`. Could add an intermediate directory that points to the model id?

Testing:
Did a run-through of the modified classification script (old one) as well as the new script. Both are working as expected!